### PR TITLE
update kind info

### DIFF
--- a/content/getting-started/install-hub.md
+++ b/content/getting-started/install-hub.md
@@ -33,6 +33,12 @@ Clone the `registration-operator`
 git clone https://github.com/open-cluster-management/registration-operator
 ```
 
+Export kubeconfig as an environment variable
+
+```
+export KUBECONFIG=~/hub-kubeconfig
+```
+
 Deploy hub
 
 ```Shell

--- a/content/getting-started/install-hub.md
+++ b/content/getting-started/install-hub.md
@@ -13,9 +13,11 @@ The are two ways to install the core control plane of open cluster management th
 
 ## Prerequisite
 
-Ensure [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) and [kustomize](https://kubernetes-sigs.github.io/kustomize/installation/) are installed.
+Ensure [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) and [kustomize](https://kubernetes-sigs.github.io/kustomize/installation) are installed.
 
-Prepare one Kubernetes cluster to function as the hub. For example, use [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) to create a hub cluster.
+Prepare one Kubernetes cluster to function as the hub. For example, use [kind](https://kind.sigs.k8s.io/docs/user/quick-start) to create a hub cluster. 
+
+For `kind`, you must use version [v0.7.0](https://github.com/kubernetes-sigs/kind/releases/tag/v0.7.0) and you must have [docker](https://docs.docker.com/get-started) installed and running.
 
 ```Shell
 # kind delete cluster --name hub # if the kind cluster is previously created and can be safely deleted

--- a/content/getting-started/register-cluster.md
+++ b/content/getting-started/register-cluster.md
@@ -13,11 +13,13 @@ After the hub is installed, you need to install the klusterlet on another cluste
 
 ## Prerequisite
 
-Ensure [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) and [kustomize](https://kubernetes-sigs.github.io/kustomize/installation/) are installed.
+Ensure [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) and [kustomize](https://kubernetes-sigs.github.io/kustomize/installation) are installed.
 
 Ensure the open-cluster-management _hub_ is installed. See [Install Hub](install-hub.md) for more information.
 
-Prepare another Kubernetes cluster to function as the managed cluster. For example, use [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) to create another cluster as below:
+Prepare another Kubernetes cluster to function as the managed cluster. For example, use [kind](https://kind.sigs.k8s.io/docs/user/quick-start) to create another cluster as below.
+
+For `kind`, you must use version [v0.7.0](https://github.com/kubernetes-sigs/kind/releases/tag/v0.7.0) and you must have [docker](https://docs.docker.com/get-started) installed and running.
 
 ```Shell
 # kind delete cluster --name cluster1 # if the kind cluster is previously created and can be safely deleted


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

Based on a dev's feedback, added `docker` as requirement for `kind`

also it seems like in order to use the `--internal` to get the proper ip address for hub secret. we must use `kind v0.7.0`. It might be due to a kind bug `https://github.com/kubernetes-sigs/kind/issues/1916`