### PR TITLE
add golang as prereq

### DIFF
--- a/content/getting-started/install-application.md
+++ b/content/getting-started/install-application.md
@@ -15,6 +15,8 @@ After hub is installed, you could install the application management components 
 
 Ensure [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) and [kustomize](https://kubernetes-sigs.github.io/kustomize/installation/) are installed.
 
+Ensure [golang](https://golang.org/doc/install) is installed, if you are planning to install from the source.
+
 Ensure the open-cluster-management _hub_ is installed. See [Install Hub](install-hub.md) for more information.
 
 

--- a/content/getting-started/install-hub.md
+++ b/content/getting-started/install-hub.md
@@ -15,6 +15,8 @@ The are two ways to install the core control plane of open cluster management th
 
 Ensure [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) and [kustomize](https://kubernetes-sigs.github.io/kustomize/installation) are installed.
 
+Ensure [golang](https://golang.org/doc/install) is installed, if you are planning to install from the source.
+
 Prepare one Kubernetes cluster to function as the hub. For example, use [kind](https://kind.sigs.k8s.io/docs/user/quick-start) to create a hub cluster. 
 
 For `kind`, you must use version [v0.7.0](https://github.com/kubernetes-sigs/kind/releases/tag/v0.7.0) and you must have [docker](https://docs.docker.com/get-started) installed and running.

--- a/content/getting-started/register-cluster.md
+++ b/content/getting-started/register-cluster.md
@@ -15,6 +15,8 @@ After the hub is installed, you need to install the klusterlet on another cluste
 
 Ensure [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) and [kustomize](https://kubernetes-sigs.github.io/kustomize/installation) are installed.
 
+Ensure [golang](https://golang.org/doc/install) is installed, if you are planning to install from the source.
+
 Ensure the open-cluster-management _hub_ is installed. See [Install Hub](install-hub.md) for more information.
 
 Prepare another Kubernetes cluster to function as the managed cluster. For example, use [kind](https://kind.sigs.k8s.io/docs/user/quick-start) to create another cluster as below.


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

another feedback improvement from a dev, we need to specify `golang` requirement if we are installing from source.