### PR TITLE
add contribute section

### DIFF
--- a/content/community/resource.md
+++ b/content/community/resource.md
@@ -18,16 +18,3 @@ See the following options to connect with the community:
 [Community meetings](https://github.com/open-cluster-management/community/projects/1)
 
 [Youtube channel](https://www.youtube.com/channel/UC7xxOh2jBM5Jfwt3fsBzOZw)
-
-## Get Involved
-
-Check out the project and consider contributing. You can pick up an issue to work on, or report a bug by creating a new issue [here](https://github.com/open-cluster-management/community/issues). When your code is ready to be reviewed, you can propose a pull request. You can find a good guide about the GitHub workflow [here](https://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project).
-
-If you intend to propose an enhancement or a new feature in open-cluster-management, submit a pull request in the [enhancements repo](https://github.com/open-cluster-management/enhancements). The proposal should follow the [kep format](https://github.com/kubernetes/enhancements/blob/master/keps/NNNN-kep-template/README.md).
-
-## Certificate of Origin
-
-By contributing to this project, you agree to the Developer Certificate of
-Origin (DCO). This document was created by the Linux Kernel community and is a
-simple statement that you, as a contributor, have the legal right to make the
-contribution. See the [DCO](https://github.com/open-cluster-management/registration-operator/blob/master/DCO) file for details.

--- a/content/contribute/_index.md
+++ b/content/contribute/_index.md
@@ -1,0 +1,4 @@
+---
+title: Contribute
+weight: 4
+---

--- a/content/contribute/contribute.md
+++ b/content/contribute/contribute.md
@@ -7,24 +7,20 @@ We know you've got great ideas for improving Open Cluster Management. So roll up
 
 ## Get Started
 
-All contributions are welcome! Open Cluster Management uses the Apache 2 license and does not require any contributor agreement to submit patches. Please open issues for any bugs or problems you encounter, ask questions in the #open-cluster-mgmt on Kubernetes Slack Channel, or get involved joining the open-cluster-management google mailing group.
-
-[Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0)
-
-[Mailing group](https://groups.google.com/g/open-cluster-management)
+All contributions are welcome! Open Cluster Management uses the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). Please open issues for any bugs or problems you encounter, ask questions in the [#open-cluster-mgmt](https://kubernetes.slack.com/archives/C01GE7YSUUF) on Kubernetes Slack Channel, or get involved joining the open-cluster-management [mailing group](https://groups.google.com/g/open-cluster-management).
 
 ## Contribute to the Source
 
 - Join the [Mailing group](https://groups.google.com/g/open-cluster-management)
 - Attend an upcoming [Community meetings](https://github.com/open-cluster-management/community/projects/1)
-- Fork the [repository](https://github.com/open-cluster-management) you wish to work on
+- Fork the [repository](https://github.com/open-cluster-management) you wish to work on. For example, [API](https://github.com/open-cluster-management/api),[Registration](https://github.com/open-cluster-management/registration), etc.
 - Get started by following the `CONTRIBUTING.md` guide in the repository you wish to work on
 
 ## Get Involved / File a Bug
 
 Check out the project and consider contributing. You can pick up an issue to work on, or report a bug by creating a new issue [here](https://github.com/open-cluster-management/community/issues). When your code is ready to be reviewed, you can propose a pull request. You can find a good guide about the GitHub workflow [here](https://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project).
 
-If you intend to propose an enhancement or a new feature in open-cluster-management, submit a pull request in the [enhancements repo](https://github.com/open-cluster-management/enhancements). The proposal should follow the [kep format](https://github.com/kubernetes/enhancements/blob/master/keps/NNNN-kep-template/README.md).
+If you intend to propose an enhancement or a new feature in open-cluster-management, submit a pull request in the [enhancements repo](https://github.com/open-cluster-management/enhancements). The proposal should follow the [kep format](https://github.com/open-cluster-management/enhancements/blob/master/guidelines/README.md).
 
 ## Certificate of Origin
 
@@ -35,4 +31,4 @@ contribution. See the [DCO](https://github.com/open-cluster-management/registrat
 
 ## Talk to Us
 - Follow the [Mailing group](https://groups.google.com/g/open-cluster-management)
-- Chat with us in the #open-cluster-mgmt on Kubernetes Slack Channel
+- Chat with us in the [#open-cluster-mgmt](https://kubernetes.slack.com/archives/C01GE7YSUUF) on Kubernetes Slack Channel

--- a/content/contribute/contribute.md
+++ b/content/contribute/contribute.md
@@ -1,0 +1,38 @@
+---
+title: Contribute to Open Cluster Management 
+weight: -20
+---
+
+We know you've got great ideas for improving Open Cluster Management. So roll up your sleeves and come join us in the community!
+
+## Get Started
+
+All contributions are welcome! Open Cluster Management uses the Apache 2 license and does not require any contributor agreement to submit patches. Please open issues for any bugs or problems you encounter, ask questions in the #open-cluster-mgmt on Kubernetes Slack Channel, or get involved joining the open-cluster-management google mailing group.
+
+[Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0)
+
+[Mailing group](https://groups.google.com/g/open-cluster-management)
+
+## Contribute to the Source
+
+- Join the [Mailing group](https://groups.google.com/g/open-cluster-management)
+- Attend an upcoming [Community meetings](https://github.com/open-cluster-management/community/projects/1)
+- Fork the [repository](https://github.com/open-cluster-management) you wish to work on
+- Get started by following the `CONTRIBUTING.md` guide in the repository you wish to work on
+
+## Get Involved / File a Bug
+
+Check out the project and consider contributing. You can pick up an issue to work on, or report a bug by creating a new issue [here](https://github.com/open-cluster-management/community/issues). When your code is ready to be reviewed, you can propose a pull request. You can find a good guide about the GitHub workflow [here](https://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project).
+
+If you intend to propose an enhancement or a new feature in open-cluster-management, submit a pull request in the [enhancements repo](https://github.com/open-cluster-management/enhancements). The proposal should follow the [kep format](https://github.com/kubernetes/enhancements/blob/master/keps/NNNN-kep-template/README.md).
+
+## Certificate of Origin
+
+By contributing to this project, you agree to the Developer Certificate of
+Origin (DCO). This document was created by the Linux Kernel community and is a
+simple statement that you, as a contributor, have the legal right to make the
+contribution. See the [DCO](https://github.com/open-cluster-management/registration-operator/blob/master/DCO) file for details.
+
+## Talk to Us
+- Follow the [Mailing group](https://groups.google.com/g/open-cluster-management)
+- Chat with us in the #open-cluster-mgmt on Kubernetes Slack Channel


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

@swopeb one of the feedback we got from the playback is that there is no "Contribute" section on our website. Turns out it's sort of hidden in the "Community" part. I created a dedicated section for "Contribute" with more contents and copied some Community stuffs over. But I feel like there is still some overlapping with "Community". Could you please take a look and comment? Thanks.