### PR TITLE
add app-ui content to project page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Contributing guidelines](#contributing-guidelines)
+    - [Contributions](#contributions)
+    - [Certificate of Origin](#certificate-of-origin)
+    - [Contributing A Patch](#contributing-a-patch)
+    - [Issue and Pull Request Management](#issue-and-pull-request-management)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Contributing guidelines
+
+## Contributions
+
+All contributions to the repository must be submitted under the terms of the [Apache Public License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+## Certificate of Origin
+
+By contributing to this project you agree to the Developer Certificate of
+Origin (DCO). This document was created by the Linux Kernel community and is a
+simple statement that you, as a contributor, have the legal right to make the
+contribution. See the [DCO](DCO) file for details.
+
+## Contributing A Patch
+
+1. Submit an issue describing your proposed change to the repo in question.
+1. The [repo owners](OWNERS) will respond to your issue promptly.
+1. Fork the desired repo, develop and test your code changes.
+1. Submit a pull request.
+
+## Issue and Pull Request Management
+
+Anyone may comment on issues and submit reviews for pull requests. However, in
+order to be assigned an issue or pull request, you must be a member of the
+[open-cluster-management](https://github.com/open-cluster-management) GitHub organization.
+
+Repo maintainers can assign you an issue or pull request by leaving a
+`/assign <your Github ID>` comment on the issue or pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,14 +21,14 @@ All contributions to the repository must be submitted under the terms of the [Ap
 By contributing to this project you agree to the Developer Certificate of
 Origin (DCO). This document was created by the Linux Kernel community and is a
 simple statement that you, as a contributor, have the legal right to make the
-contribution. See the [DCO](DCO) file for details.
+contribution. See the DCO file for details.
 
 ## Contributing A Patch
 
 1. Submit an issue describing your proposed change to the repo in question.
-1. The [repo owners](OWNERS) will respond to your issue promptly.
-1. Fork the desired repo, develop and test your code changes.
-1. Submit a pull request.
+2. The repo owners will respond to your issue promptly.
+3. Fork the desired repo, develop and test your code changes.
+4. Submit a pull request.
 
 ## Issue and Pull Request Management
 

--- a/DCO
+++ b/DCO
@@ -1,0 +1,37 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+# Security Response
+
+If you've found a security issue that you'd like to disclose confidentially please contact Red Hat's Product Security team. 
+Details at https://access.redhat.com/security/team/contact

--- a/content/concepts/architecture.md
+++ b/content/concepts/architecture.md
@@ -34,6 +34,11 @@ A multi-cluster application uses a Kubernetes specification, but with additional
 A multi-cluster application allows you to deploy resources on multiple clusters, while maintaining easy-to-reconcile service routes, as well as full control of Kubernetes resource updates for all aspects of the application.
 
 
+### Application console (work in progress)
+
+The _Application console_ defines the user interface used to create and manage application resources deployed on your managed clusters through the use of _Application lifecycle_ subscription operators. 
+
+
 ## Governance and risk (work in progress)
 
 _Governance and risk_ is the term used to define the processes that are used to manage security and compliance from the hub cluster. Ensure the security of your cluster with the extensible policy framework. After you configure a hub cluster and a managed cluster, you can create, modify and delete policies on the hub and apply policies to managed clusters.

--- a/content/concepts/architecture.md
+++ b/content/concepts/architecture.md
@@ -36,7 +36,7 @@ A multi-cluster application allows you to deploy resources on multiple clusters,
 
 ### Application console (work in progress)
 
-The _Application console_ defines the user interface used to create and manage application resources deployed on your managed clusters through the use of _Application lifecycle_ subscription operators. 
+The _Application console_ defines the user interface used to create and manage application resources deployed on your managed clusters through the use of _Application lifecycle_ subscription operators.
 
 
 ## Governance and risk (work in progress)

--- a/content/concepts/roadmap.md
+++ b/content/concepts/roadmap.md
@@ -1,0 +1,8 @@
+---
+title: Roadmap
+weight: -20
+---
+
+This page tells you the roadmap for components in open-cluster-management.
+
+Work in progress


### PR DESCRIPTION
Signed-off-by: Richie Piya <rpiyasirisilp@gmail.com>

https://github.com/open-cluster-management/backlog/issues/9628

These 2 subsections are a part of the "Concepts" section in the project page: https://open-cluster-management.io

**1. Architecture**
<img width="1072" alt="Screen Shot 2021-02-25 at 12 00 03 PM" src="https://user-images.githubusercontent.com/39634227/109188676-2cacfe80-7761-11eb-999b-9a232549cf53.png">
<img width="1176" alt="Screen Shot 2021-02-25 at 11 59 20 AM" src="https://user-images.githubusercontent.com/39634227/109188680-2d459500-7761-11eb-96fe-c2f95d6ddc7f.png">

**2. Roadmap**
<img width="1034" alt="Screen Shot 2021-02-25 at 11 59 29 AM" src="https://user-images.githubusercontent.com/39634227/109188665-29197780-7761-11eb-81d1-06ec61ebd02e.png">
