### PR TITLE
Update docs to support OS X for getting started and use kind version >= 0.7

### DIFF
--- a/content/getting-started/install-application.md
+++ b/content/getting-started/install-application.md
@@ -30,18 +30,19 @@ git clone https://github.com/open-cluster-management/multicloud-operators-subscr
 Deploy subscription operators to the hub cluster.
 
 ```Shell
-export KUBECONFIG=</path/to/hub_cluster/.kube/config> # export KUBECONFIG=~/hub-kubeconfig
+export TRAVIS_BUILD=0
+kubectl config use-context kind-hub
 cd multicloud-operators-subscription
-make deploy-community-hub
+make deploy-community-hub # make deploy-community-hub GO_REQUIRED_MIN_VERSION:= # if you see warnings regarding go version
 ```
 
 Deploy subscription operators to managed cluster(s).
 
 ```Shell
 export HUB_KUBECONFIG=</path/to/hub_cluster/.kube/config> # export HUB_KUBECONFIG=~/hub-kubeconfig
-export KUBECONFIG=</path/to/managed_cluster/.kube/config> # export KUBECONFIG=~/cluster1-kubeconfig
+kubectl config use-context kind-cluster1
 export MANAGED_CLUSTER_NAME=<managed cluster name> # export MANAGED_CLUSTER_NAME=cluster1
-make deploy-community-managed
+make deploy-community-managed # make deploy-community-managed GO_REQUIRED_MIN_VERSION:= # if you see warnings regarding go version
 ```
 
 ## Install from OperatorHub
@@ -49,10 +50,10 @@ If you are using OpenShift or have `OLM` installed in your cluster, you are able
 
 ## What is next
 
-After a successfull deployment, test the subscription operator with a `helm` subscription. Run the following command:
+After a successful deployment, test the subscription operator with a `helm` subscription. Run the following command:
 
 ```Shell
-export KUBECONFIG=</path/to/hub_cluster/.kube/config> # export KUBECONFIG=~/hub-kubeconfig
+kubectl config use-context kind-hub
 cd multicloud-operators-subscription
 kubectl apply -f examples/helmrepo-hub-channel
 ```
@@ -60,8 +61,8 @@ kubectl apply -f examples/helmrepo-hub-channel
 After a while, you should see the subscription propagated to the managed cluster and the Helm app installed. To confirm, run the following command:
 
 ```Shell
-$ export KUBECONFIG=</path/to/managed_cluster/.kube/config> # export KUBECONFIG=~/cluster1-kubeconfig
-$ kubectl get appsub 
+$ kubectl config use-context kind-cluster1
+$ kubectl get subscriptions.apps 
 NAME        STATUS       AGE    LOCAL PLACEMENT   TIME WINDOW
 nginx-sub   Subscribed   107m   true  
 $ kubectl get pod

--- a/content/getting-started/install-hub.md
+++ b/content/getting-started/install-hub.md
@@ -17,9 +17,15 @@ Ensure [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) and [ku
 
 Ensure [golang](https://golang.org/doc/install) is installed, if you are planning to install from the source.
 
-Prepare one Kubernetes cluster to function as the hub. For example, use [kind](https://kind.sigs.k8s.io/docs/user/quick-start) to create a hub cluster. 
+Prepare one Kubernetes cluster to function as the hub. For example, use [kind](https://kind.sigs.k8s.io/docs/user/quick-start) to create a hub cluster. To use kind, you will need [docker](https://docs.docker.com/get-started) installed and running.
 
-For `kind`, you must use version [v0.7.0](https://github.com/kubernetes-sigs/kind/releases/tag/v0.7.0) and you must have [docker](https://docs.docker.com/get-started) installed and running.
+If running on OS X, you'll need also gnu-sed installed:
+
+```Shell
+brew install gnu-sed
+```
+
+To create the hub cluster with kind, run:
 
 ```Shell
 # kind delete cluster --name hub # if the kind cluster is previously created and can be safely deleted
@@ -35,10 +41,10 @@ Clone the `registration-operator`
 git clone https://github.com/open-cluster-management/registration-operator
 ```
 
-Export the soon-to-be hub kube config as an environment variable
+Ensure the `kubectl` context is set to point to the hub cluster:
 
 ```Shell
-export KUBECONFIG=</path/to/hub_cluster/.kube/config> # export KUBECONFIG=~/hub-kubeconfig
+kubectl config use-context kind-hub
 ```
 
 Deploy hub

--- a/content/getting-started/register-cluster.md
+++ b/content/getting-started/register-cluster.md
@@ -19,9 +19,7 @@ Ensure [golang](https://golang.org/doc/install) is installed, if you are plannin
 
 Ensure the open-cluster-management _hub_ is installed. See [Install Hub](install-hub.md) for more information.
 
-Prepare another Kubernetes cluster to function as the managed cluster. For example, use [kind](https://kind.sigs.k8s.io/docs/user/quick-start) to create another cluster as below.
-
-For `kind`, you must use version [v0.7.0](https://github.com/kubernetes-sigs/kind/releases/tag/v0.7.0) and you must have [docker](https://docs.docker.com/get-started) installed and running.
+Prepare another Kubernetes cluster to function as the managed cluster. For example, use [kind](https://kind.sigs.k8s.io/docs/user/quick-start) to create another cluster as below. To use kind, you will need [docker](https://docs.docker.com/get-started) installed and running.
 
 ```Shell
 # kind delete cluster --name cluster1 # if the kind cluster is previously created and can be safely deleted
@@ -37,17 +35,17 @@ If you have not already done so, clone the `registration-operator`.
 git clone https://github.com/open-cluster-management/registration-operator
 ```
 
-Export the soon-to-be managed cluster kube config as an environment variable
+Ensure the `kubectl` context is set to point to the managed cluster:
 
 ```Shell
-export KUBECONFIG=</path/to/managed_cluster/.kube/config> # export KUBECONFIG=~/cluster1-kubeconfig
+kubectl config use-context kind-cluster1
 ```
 
 Deploy agent on a managed `kind` cluster.
 
 ```Shell
 cd registration-operator
-export KLUSTERLET_KIND_KUBECONFIG=$KUBECONFIG
+export KLUSTERLET_KIND_KUBECONFIG=~/cluster1-kubeconfig
 export KIND_CLUSTER=<managed cluster name> # export KIND_CLUSTER=cluster1
 export HUB_KIND_KUBECONFIG=</path/to/hub_kind_cluster/.kube/config> # export HUB_KIND_KUBECONFIG=~/hub-kubeconfig
 make deploy-spoke-kind # make deploy-spoke-kind GO_REQUIRED_MIN_VERSION:= # if you see warnings regarding go version
@@ -62,7 +60,7 @@ After a successful deployment, a `certificatesigningrequest` and a `managedclust
 be created on the hub.
 
 ```Shell
-$ export KUBECONFIG=</path/to/hub_cluster/.kube/config> # export KUBECONFIG=~/hub-kubeconfig
+$ kubectl config use-context kind-hub
 $ kubectl get csr
 NAME                              AGE   REQUESTOR                       CONDITION
 <managed cluster name>-<suffix>   41s   kubernetes-admin                Pending
@@ -120,7 +118,7 @@ kubectl -n <managed cluster name> get manifestwork/mw-01 -o yaml # kubectl -n cl
 Check on the managed cluster and see the _hello_ Pod has been deployed from the hub.
 
 ```Shell
-$ export KUBECONFIG=</path/to/managed_cluster/.kube/config> # export KUBECONFIG=~/cluster1-kubeconfig
+$ kubectl config use-context kind-cluster1
 $ kubectl -n default get pod
 NAME    READY   STATUS    RESTARTS   AGE
 hello   1/1     Running   0          108s


### PR DESCRIPTION
This PR goes together with https://github.com/open-cluster-management/registration-operator/pull/103 and addresses https://github.com/open-cluster-management/registration-operator/issues/102. 

The instructions for the patched version have been tested on OS X and Linux.

Signed-off-by: Paolo Dettori <dettori@us.ibm.com>