### PR TITLE
rename most of the hub reference to cluster manager, disable install related guides for now

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -12,7 +12,7 @@ The Open Cluster Management project consists of several multicluster components,
 
 ## Quick start
 
-Install and create a [Cluster Manager](https://operatorhub.io/operator/cluster-manager) on your _hub_ cluster. For more details see [Install Hub](getting-started/install-hub.md).
+Install and create a [Cluster Manager](https://operatorhub.io/operator/cluster-manager) on your _hub_ cluster. For more details see [Install Cluster Manager](getting-started/install-cluster-manager).
 
 Install and create a [Klusterlet agent](https://operatorhub.io/operator/klusterlet) on your _managed_ cluster.
-For more details see [Install Klusterlet](getting-started/register-cluster.md).
+For more details see [Install Klusterlet](getting-started/register-cluster).

--- a/content/getting-started/install-application.md
+++ b/content/getting-started/install-application.md
@@ -3,7 +3,7 @@ title: Install Application management
 weight: 3
 ---
 
-After hub is installed, you could install the application management components to the hub.
+After the cluster manager is installed, you could install the application management components to the hub cluster.
 
 <!-- spellchecker-disable -->
 
@@ -17,7 +17,7 @@ Ensure [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) and [k
 
 Ensure [golang](https://golang.org/doc/install) is installed, if you are planning to install from the source.
 
-Ensure the open-cluster-management _hub_ is installed. See [Install Hub](install-hub.md) for more information.
+Ensure the open-cluster-management cluster manager is installed. See [Install Cluster Manager](../install-cluster-manager) for more information.
 
 
 ## Install from source

--- a/content/getting-started/install-cluster-manager.md
+++ b/content/getting-started/install-cluster-manager.md
@@ -1,5 +1,5 @@
 ---
-title: Install Hub
+title: Install Cluster Manager
 weight: 1
 ---
 
@@ -55,4 +55,4 @@ make deploy-hub # make deploy-hub GO_REQUIRED_MIN_VERSION:= # if you see warning
 ```
 
 ## Install from OperatorHub
-If you are using OpenShift or have `OLM` installed in your cluster, you are able to install the hub with a released version from OperatorHub. Details can be found [here](https://operatorhub.io/operator/cluster-manager).
+If you are using OpenShift or have `OLM` installed in your cluster, you are able to install the cluster manager with a released version from OperatorHub. Details can be found [here](https://operatorhub.io/operator/cluster-manager).

--- a/content/getting-started/install-discovery.md
+++ b/content/getting-started/install-discovery.md
@@ -1,6 +1,7 @@
 ---
 title: Install Discovery
 weight: 3
+geekdocHidden: true
 ---
 
 After the hub is installed, the discovery component can be installed to help discover available clusters.

--- a/content/getting-started/install-multiclusterhub-operator.md
+++ b/content/getting-started/install-multiclusterhub-operator.md
@@ -1,6 +1,7 @@
 ---
 title: Install MultiClusterHub Operator
 weight: 3
+geekdocHidden: true
 ---
 
 ## Install from source

--- a/content/getting-started/install-policy-controllers.md
+++ b/content/getting-started/install-policy-controllers.md
@@ -19,7 +19,7 @@ Ensure [golang](https://golang.org/doc/install) is installed, if you are plannin
 
 Prepare one Kubernetes cluster to function as the hub. For example, use [kind](https://kind.sigs.k8s.io/docs/user/quick-start) to create a hub cluster. To use kind, you will need [docker](https://docs.docker.com/get-started) installed and running.
 
-Ensure the open-cluster-management _policy framework_ is installed. See [Install Install Policy Framework](install-policy-framework.md) for more information.
+Ensure the open-cluster-management policy framework is installed. See [Install Policy Framework](../install-policy-framework) for more information.
 
 ## Install configuration policy controller
 Clone the `config-policy-controller`

--- a/content/getting-started/install-policy-framework.md
+++ b/content/getting-started/install-policy-framework.md
@@ -3,7 +3,7 @@ title: Install Policy Framework
 weight: 4
 ---
 
-After hub and klusterlet is installed, you could install the policy framework components to the hub and the managed clusters.
+After cluster manager and klusterlet are installed, you could install the policy framework components to the hub and the managed clusters.
 
 <!-- spellchecker-disable -->
 
@@ -19,11 +19,11 @@ Ensure [golang](https://golang.org/doc/install) is installed, if you are plannin
 
 Prepare one Kubernetes cluster to function as the hub. For example, use [kind](https://kind.sigs.k8s.io/docs/user/quick-start) to create a hub cluster. To use kind, you will need [docker](https://docs.docker.com/get-started) installed and running.
 
-Ensure the open-cluster-management _hub_ is installed. See [Install Hub](install-hub.md) for more information.
+Ensure the open-cluster-management cluster manager is installed. See [Install Cluster Manager](../install-cluster-manager) for more information.
 
-Ensure the open-cluster-management _klusterlet_ is installed. See [Install Klusterlet](register-cluster.md) for more information.
+Ensure the open-cluster-management klusterlet is installed. See [Install Klusterlet](../register-cluster) for more information.
 
-Ensure the open-cluster-management _Application_ is installed. See [Install Application management](install-application.md) for more information.
+Ensure the open-cluster-management application management is installed. See [Install Application management](../install-application) for more information.
 
 ## Install from prebuilt images on Quay.io
 Clone the `governance-policy-framework`

--- a/content/getting-started/register-cluster.md
+++ b/content/getting-started/register-cluster.md
@@ -3,7 +3,7 @@ title: Install Klusterlet
 weight: 2
 ---
 
-After the hub is installed, you need to install the klusterlet on another cluster so that it can be registered and managed by the hub.
+After the cluster manager is installed on the hub cluster, you need to install the klusterlet agent on another cluster so that it can be registered and managed by the hub cluster.
 
 <!-- spellchecker-disable -->
 
@@ -17,7 +17,7 @@ Ensure [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) and [ku
 
 Ensure [golang](https://golang.org/doc/install) is installed, if you are planning to install from the source.
 
-Ensure the open-cluster-management _hub_ is installed. See [Install Hub](install-hub.md) for more information.
+Ensure the open-cluster-management cluster manager is installed on the hub cluster. See [Install Cluster Manager](../install-cluster-manager) for more information.
 
 Prepare another Kubernetes cluster to function as the managed cluster. For example, use [kind](https://kind.sigs.k8s.io/docs/user/quick-start) to create another cluster as below. To use kind, you will need [docker](https://docs.docker.com/get-started) installed and running.
 
@@ -55,8 +55,7 @@ If you are using OpenShift or have `OLM` installed in your cluster, you are able
 
 ## What is next
 
-After a successful deployment, a `certificatesigningrequest` and a `managedcluster` will
-be created on the hub.
+After a successful deployment, a `certificatesigningrequest` and a `managedcluster` will be created on the hub cluster.
 
 ```Shell
 $ kubectl config use-context kind-hub
@@ -107,14 +106,14 @@ spec:
         restartPolicy: OnFailure
 ```
 
-Apply the yaml file to the hub.
+Apply the yaml file to the hub cluster.
 
 ```Shell
 kubectl apply -f manifest-work.yaml
 kubectl -n <managed cluster name> get manifestwork/mw-01 -o yaml # kubectl -n cluster1 get manifestwork/mw-01 -o yaml
 ```
 
-Check on the managed cluster and see the _hello_ Pod has been deployed from the hub.
+Check on the managed cluster and see the _hello_ Pod has been deployed from the hub cluster.
 
 ```Shell
 $ kubectl config use-context kind-cluster1


### PR DESCRIPTION
- Rename most of the hub reference to cluster manager
- After discussing with the open source install guild representative, we decided that the install instructions are not community read, so hide those pages for now.
- Some broken link fixes

Signed-off-by: Mike Ng <ming@redhat.com>