### PR TITLE
add a pointer to community arch diag

### DIFF
--- a/content/concepts/architecture.md
+++ b/content/concepts/architecture.md
@@ -5,6 +5,8 @@ weight: -20
 
 This page tells you the architecture and basic concepts in open-cluster-management.
 
+![Example image](https://github.com/open-cluster-management/community/raw/main/assets/ocm-arch.png)
+
 <!-- spellchecker-disable -->
 
 {{< toc >}}

--- a/content/concepts/architecture.md
+++ b/content/concepts/architecture.md
@@ -5,7 +5,7 @@ weight: -20
 
 This page tells you the architecture and basic concepts in open-cluster-management.
 
-![Example image](https://github.com/open-cluster-management/community/raw/main/assets/ocm-arch.png)
+![Architecture diagram](https://github.com/open-cluster-management/community/raw/main/assets/ocm-arch.png)
 
 <!-- spellchecker-disable -->
 


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

This will point to the https://github.com/open-cluster-management/community/raw/main/assets/ocm-arch.png

which is being updated in https://github.com/open-cluster-management/community/pull/37 to include the newly presented policy.

FYI @juliana-hsu 