### PR TITLE
remove some hugo geek doc specific links and some minor fixes to cluster and policy

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -39,27 +39,9 @@ disablePathToLower = true
   # You can also specify this parameter per page in front matter.
   geekdocBreadcrumb = false
 
-  # (Optional, default none) Set source repository location
-  # Used for 'Edit this page' links
-  # You can also specify this parameter per page in front matter.
-  geekdocRepo = "https://github.com/open-cluster-management/website"
-
-  # (Optional, default none) Enable 'Edit this page' links. Requires 'GeekdocRepo' param
-  # and path must point to 'content' directory of repo.
-  # You can also specify this parameter per page in front matter.
-  geekdocEditPath = "edit/main/content"
-
   # (Optional, default true) Enables search function with flexsearch.
   # Index is built on the fly and might slowdown your website.
   geekdocSearch = false
-
-  # (Optional, default none) Add a link to your Legal Notice page to the site footer.
-  # It can be either a remote url or a local file path relative to your content directory.
-  geekdocLegalNotice = "https://blog.example.com/legal"
-
-  # (Optional, default none) Add a link to your Privacy Policy page to the site footer.
-  # It can be either a remote url or a local file path relative to your content directory.
-  geekdocPrivacyPolicy = "/privacy"
 
   # (Optional, default true) Add an anchor link to headlines.
   geekdocAnchor = true

--- a/config.toml
+++ b/config.toml
@@ -39,6 +39,16 @@ disablePathToLower = true
   # You can also specify this parameter per page in front matter.
   geekdocBreadcrumb = false
 
+    # (Optional, default none) Set source repository location
+  # Used for 'Edit this page' links
+  # You can also specify this parameter per page in front matter.
+  geekdocRepo = "https://github.com/open-cluster-management/website"
+
+    # (Optional, default none) Enable 'Edit this page' links. Requires 'GeekdocRepo' param
+  # and path must point to 'content' directory of repo.
+  # You can also specify this parameter per page in front matter.
+  geekdocEditPath = "edit/main/content"
+
   # (Optional, default true) Enables search function with flexsearch.
   # Index is built on the fly and might slowdown your website.
   geekdocSearch = false

--- a/content/getting-started/install-cluster-lifecycle.md
+++ b/content/getting-started/install-cluster-lifecycle.md
@@ -52,7 +52,7 @@ You must meet the following prerequisites to use the cluster lifecycle:
 
 5. Verify `managedcluster-import-controller` is running:
    ```Shell
-   kubectl get po -n open-cluster-management | grep managedcluster-import-controller   
+   $ kubectl get po -n open-cluster-management | grep managedcluster-import-controller   
    managedcluster-import-controller-686b9dff46-flk9d   1/1     Running   0          6m47s
    ```
 
@@ -62,7 +62,7 @@ You must meet the following prerequisites to use the cluster lifecycle:
 ### Auto register a Hive-created cluster
 1. If you created a OKD/Openshift cluster using [Hive](https://github.com/openshift/hive/blob/master/docs/using-hive.md#using-hive), you can auto-import the cluster by simply creating a managedcluster resource:
 
-   ```
+   ```Shell
    apiVersion: cluster.open-cluster-management.io/v1
    kind: ManagedCluster
    metadata:
@@ -77,7 +77,7 @@ You must meet the following prerequisites to use the cluster lifecycle:
 
 2. Verify that the cluster is available on the _cluster manager_:
    ```Shell
-   kubectl get managedcluster                                                                                                    
+   $ kubectl get managedcluster                                                                                                    
    NAME        HUB ACCEPTED   MANAGED CLUSTER URLS   JOINED   AVAILABLE   AGE
    hive-test   true                                  True     True        10m
 
@@ -88,7 +88,7 @@ You must meet the following prerequisites to use the cluster lifecycle:
 
 1. Create a managedcluster resource:
 
-   ```
+   ```Shell
    apiVersion: cluster.open-cluster-management.io/v1
    kind: ManagedCluster
    metadata:
@@ -115,7 +115,7 @@ You must meet the following prerequisites to use the cluster lifecycle:
 
 5. Verify that the cluster is available on the _cluster manager_:
    ```Shell
-   kubectl get managedcluster                                                                                                    
+   $ kubectl get managedcluster                                                                                                    
    NAME        HUB ACCEPTED   MANAGED CLUSTER URLS   JOINED   AVAILABLE   AGE
    test-name   true                                  True     True        21m
    ```

--- a/content/getting-started/install-policy-controllers.md
+++ b/content/getting-started/install-policy-controllers.md
@@ -45,7 +45,7 @@ Complete the following procedure to install the configuration policy controller:
 3. Ensure the pod is running on the managed cluster. Run the following command:
 
    ```Shell
-   kubectl get pods -n open-cluster-management-agent-addon
+   $ kubectl get pods -n open-cluster-management-agent-addon
    NAME                                               READY   STATUS    RESTARTS   AGE
    ...
    config-policy-controller-7f8fb64d8c-pmfx4          1/1     Running   0          44s
@@ -76,7 +76,7 @@ Complete the following steps to install the certificate policy controller:
 3. Ensure the pod is running on the managed cluster. Run the following command:
 
    ```Shell
-   kubectl get pods -n open-cluster-management-agent-addon
+   $ kubectl get pods -n open-cluster-management-agent-addon
    NAME                                    READY   STATUS    RESTARTS   AGE
    ...
    cert-policy-controller-6678fc7c-lw6m9   1/1     Running   0          4m20s
@@ -107,7 +107,7 @@ Complete the following step to install the IAM policy controller:
 3. Ensure the pod is running on the managed cluster. Run the following command:
 
    ```Shell
-   kubectl get pods -n open-cluster-management-agent-addon
+   $ kubectl get pods -n open-cluster-management-agent-addon
    NAME                                     READY   STATUS    RESTARTS   AGE
    ...
    iam-policy-controller-7c5f746866-v65jb   1/1     Running   0          2m43s
@@ -123,7 +123,7 @@ The IAM policy controller is installed.
    ```Shell
    kubectl config use-context <hub cluster context> # kubectl config use-context kind-hub
    
-   kubectl apply -n default -f https://raw.githubusercontent.com/open-cluster-management/policy-collection/main/stable/CM-Configuration- Management/policy-pod.yaml
+   kubectl apply -n default -f https://raw.githubusercontent.com/open-cluster-management/policy-collection/main/stable/CM-Configuration-Management/policy-pod.yaml
    policy.policy.open-cluster-management.io/policy-pod created
    placementbinding.policy.open-cluster-management.io/binding-policy-pod created
    placementrule.apps.open-cluster-management.io/placement-policy-pod created
@@ -139,7 +139,7 @@ The IAM policy controller is installed.
 3. To confirm that the managed cluster is selected by `PlacementRule`, run the following command:
 
    ```Shell
-   kubectl get -n default placementrule.apps.open-cluster-management.io/placement-policy-pod -oyaml
+   $ kubectl get -n default placementrule.apps.open-cluster-management.io/placement-policy-pod -oyaml
    ...
    status:
      decisions:
@@ -158,9 +158,9 @@ The IAM policy controller is installed.
 5. After a few seconds, your policy is propagated to the managed cluster. To confirm, run the following command:
 
    ```Shell
-   export WATCH_NAMESPACE=<managed cluster name> # export WATCH_NAMESPACE=cluster1
-   kubectl config use-context <managed cluster context> # kubectl config use-context kind-$WATCH_NAMESPACE
-   kubectl get policy -A
+   $ export WATCH_NAMESPACE=<managed cluster name> # export WATCH_NAMESPACE=cluster1
+   $ kubectl config use-context <managed cluster context> # kubectl config use-context kind-$WATCH_NAMESPACE
+   $ kubectl get policy -A
    NAMESPACE   NAME                 AGE
    cluster1    default.policy-pod   1m39s
    ```
@@ -168,7 +168,7 @@ The IAM policy controller is installed.
 6. The missing pod is created by the policy on the managed cluster. To confirm, run the following command:
 
    ```Shell
-   kubectl get pod -n default
+   $ kubectl get pod -n default
    NAME               READY   STATUS    RESTARTS   AGE
    sample-nginx-pod   1/1     Running   0          23s
    ```

--- a/content/getting-started/install-policy-framework.md
+++ b/content/getting-started/install-policy-framework.md
@@ -50,7 +50,7 @@ Complete the following steps to install the policy framework from prebuild image
 3. Ensure the pods are running on hub with the following command:
 
    ```Shell
-   kubectl get pods -n open-cluster-management 
+   $ kubectl get pods -n open-cluster-management 
    NAME                                           READY   STATUS    RESTARTS   AGE
    governance-policy-propagator-8c77f7f5f-kthvh   1/1     Running   0          94s
    ```
@@ -71,7 +71,7 @@ Complete the following steps to install the policy framework from prebuild image
 5. Verify that the pods are running with the following command:
 
    ```Shell
-   kubectl get pods -n open-cluster-management-agent-addon 
+   $ kubectl get pods -n open-cluster-management-agent-addon 
    NAME                                               READY   STATUS    RESTARTS   AGE
    governance-policy-spec-sync-6474b6d898-tmkw6       1/1     Running   0          2m14s
    governance-policy-status-sync-84cbb795df-pgbgt     1/1     Running   0          2m14s

--- a/themes/hugo-geekdoc/layouts/partials/site-footer.html
+++ b/themes/hugo-geekdoc/layouts/partials/site-footer.html
@@ -1,9 +1,5 @@
 <footer class="gdoc-footer">
     <div class="container flex flex-wrap">
-        <span class="gdoc-footer__item">
-            Built with <a href="https://gohugo.io/" class="gdoc-footer__link">Hugo</a> and
-            <svg class="icon heart"><use xlink:href="#heart"></use></svg>
-        </span>
         {{ with .Site.Params.GeekdocLegalNotice }}
         <span class="gdoc-footer__item">
             <a href="{{ . | relURL }}" class="gdoc-footer__link">Legal Notice</a>


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

quick fixes.
currently, our web site has a lot of hugo/geekdoc related items

![image](https://user-images.githubusercontent.com/58747157/116141542-d26be380-a6a6-11eb-864c-df99e70f3316.png)

after removing all the hugo/geekdoc looks like this

![image](https://user-images.githubusercontent.com/58747157/116141738-152dbb80-a6a7-11eb-882d-123fe4d0ae8e.png)