### PR TITLE
update the instruction for installing from operatorhub

### DIFF
--- a/content/getting-started/core/cluster-manager.md
+++ b/content/getting-started/core/cluster-manager.md
@@ -54,5 +54,5 @@ cd registration-operator
 make deploy-hub # make deploy-hub GO_REQUIRED_MIN_VERSION:= # if you see warnings regarding go version
 ```
 
-## Install from OperatorHub
-If you are using OpenShift or have `OLM` installed in your cluster, you are able to install the cluster manager with a released version from OperatorHub. Details can be found [here](https://operatorhub.io/operator/cluster-manager).
+## Install community operator from OperatorHub.io
+If you are using OKD, OpenShift or have `OLM` installed in your cluster, you are able to install the cluster manager community operator with a released version from [OperatorHub.io](https://operatorhub.io). Details can be found [here](https://operatorhub.io/operator/cluster-manager).

--- a/content/getting-started/core/cluster-manager.md
+++ b/content/getting-started/core/cluster-manager.md
@@ -55,4 +55,4 @@ make deploy-hub # make deploy-hub GO_REQUIRED_MIN_VERSION:= # if you see warning
 ```
 
 ## Install community operator from OperatorHub.io
-If you are using OKD, OpenShift or have `OLM` installed in your cluster, you are able to install the cluster manager community operator with a released version from [OperatorHub.io](https://operatorhub.io). Details can be found [here](https://operatorhub.io/operator/cluster-manager).
+If you are using OKD, OpenShift, or have `OLM` installed in your cluster, you can install the cluster manager community operator with a released version from [OperatorHub.io](https://operatorhub.io). Details can be found [here](https://operatorhub.io/operator/cluster-manager).

--- a/content/getting-started/core/register-cluster.md
+++ b/content/getting-started/core/register-cluster.md
@@ -50,8 +50,8 @@ export HUB_KIND_KUBECONFIG=</path/to/hub_kind_cluster/.kube/config> # export HUB
 make deploy-spoke-kind # make deploy-spoke-kind GO_REQUIRED_MIN_VERSION:= # if you see warnings regarding go version
 ```
 
-## Install from OperatorHub
-If you are using OpenShift or have `OLM` installed in your cluster, you are able to install the klusterlet with a released version from OperatorHub. Details can be found [here](https://operatorhub.io/operator/klusterlet).
+## Install community operator from OperatorHub.io
+If you are using OKD, OpenShift or have `OLM` installed in your cluster, you are able to install the klusterlet agent community operator with a released version from [OperatorHub.io](https://operatorhub.io). Details can be found [here](https://operatorhub.io/operator/klusterlet).
 
 ## What is next
 

--- a/content/getting-started/core/register-cluster.md
+++ b/content/getting-started/core/register-cluster.md
@@ -51,7 +51,7 @@ make deploy-spoke-kind # make deploy-spoke-kind GO_REQUIRED_MIN_VERSION:= # if y
 ```
 
 ## Install community operator from OperatorHub.io
-If you are using OKD, OpenShift or have `OLM` installed in your cluster, you are able to install the klusterlet agent community operator with a released version from [OperatorHub.io](https://operatorhub.io). Details can be found [here](https://operatorhub.io/operator/klusterlet).
+If you are using OKD, OpenShift, or have `OLM` installed in your cluster, you can install the klusterlet agent community operator with a released version from [OperatorHub.io](https://operatorhub.io). Details can be found [here](https://operatorhub.io/operator/klusterlet).
 
 ## What is next
 

--- a/content/getting-started/integration/app-lifecycle.md
+++ b/content/getting-started/integration/app-lifecycle.md
@@ -49,7 +49,7 @@ make deploy-community-managed # make deploy-community-managed GO_REQUIRED_MIN_VE
 ```
 
 ## Install community operator from OperatorHub.io
-If you are using OKD, OpenShift or have `OLM` installed in your cluster, you are able to install the multicluster subscription community operator with a released version from the [OperatorHub.io](https://operatorhub.io). Details can be found [here](https://operatorhub.io/operator/multicluster-operators-subscription).
+If you are using OKD, OpenShift, or have `OLM` installed in your cluster, you can install the multicluster subscription community operator with a released version from the [OperatorHub.io](https://operatorhub.io). Details can be found [here](https://operatorhub.io/operator/multicluster-operators-subscription).
 
 ## What is next
 

--- a/content/getting-started/integration/app-lifecycle.md
+++ b/content/getting-started/integration/app-lifecycle.md
@@ -48,8 +48,8 @@ export MANAGED_CLUSTER_NAME=<managed cluster name> # export MANAGED_CLUSTER_NAME
 make deploy-community-managed # make deploy-community-managed GO_REQUIRED_MIN_VERSION:= # if you see warnings regarding go version
 ```
 
-## Install from OperatorHub
-If you are using OpenShift or have `OLM` installed in your cluster, you are able to install the multicluster subscription operator with a released version from the OperatorHub. Details can be found [here](https://operatorhub.io/operator/multicluster-operators-subscription).
+## Install community operator from OperatorHub.io
+If you are using OKD, OpenShift or have `OLM` installed in your cluster, you are able to install the multicluster subscription community operator with a released version from the [OperatorHub.io](https://operatorhub.io). Details can be found [here](https://operatorhub.io/operator/multicluster-operators-subscription).
 
 ## What is next
 


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

FYI @berenss the `## Install community operator from OperatorHub.io` change will update both the link and the header. Thanks.

Scott wants to make the following changes:
![image](https://user-images.githubusercontent.com/58747157/116718892-7526a980-a9a8-11eb-844c-3834248f4e53.png)
