### PR TITLE
Fix Hugo version in postsubmit workflow to resolve build errors

### DIFF
--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.125.5'
+          hugo-version: '0.146.0'
           extended: true
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Problem

The postsubmit GitHub action was failing with the following error:

```
WARN  Module "open-cluster-management.io/open-cluster-management-io.github.io" is not compatible with this Hugo version: Min 0.146.0 extended
WARN  Module "github.com/google/docsy" is not compatible with this Hugo version: Min 0.146.0 extended
Error: error building site: parse failed: template: _partials/scripts/katex.html:6: function "try" not defined
```

## Root Cause

- The `hugo.yaml` configuration file specifies a minimum Hugo version requirement of `0.146.0 extended`
- The postsubmit workflow was using Hugo version `0.125.5`
- The `try` function used in KaTeX templates is only available in newer Hugo versions

## Solution

Update the Hugo version in `.github/workflows/postsubmit.yml` from `0.125.5` to `0.146.0` to match the minimum version requirement.

## Testing

- ✅ Local build with Hugo v0.147.8 works successfully
- ✅ The presubmit workflow already uses the correct Hugo version (0.146.0)
- ✅ No breaking changes expected as this only updates to the minimum required version

## Changes

- Updated Hugo version in postsubmit workflow from `0.125.5` to `0.146.0`
- Maintained `extended: true` configuration

This fix ensures the postsubmit workflow uses a Hugo version that is compatible with the project's requirements and supports all the template functions being used.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author