### PR TITLE
docs: clarify network requirements for hub and managed cluster scenarios

### DIFF
--- a/content/en/docs/getting-started/installation/start-the-control-plane.md
+++ b/content/en/docs/getting-started/installation/start-the-control-plane.md
@@ -97,6 +97,20 @@ clusteradm join \
 It's recommended to save the command somewhere secure for future use. If it's lost, you can use
 `clusteradm get token` to get the generated command again.
 
+**Important Note on Network Accessibility:**
+
+The `--hub-apiserver` URL in the generated command must be network-accessible from your managed clusters. Consider the following scenarios:
+
+- **Local hub cluster (kind, minikube, etc.)**: The generated URL will typically be a localhost address (e.g., `https://127.0.0.1:xxxxx`). This URL is only accessible from your local machine and **will not work** for remote managed clusters hosted on cloud providers (GKE, EKS, AKS, etc.).
+
+- **Cloud-hosted managed clusters**: If you plan to register managed clusters running on cloud providers (GKE, EKS, AKS, etc.), your hub cluster must be network-accessible from those cloud environments. This means:
+  - Use a cloud-hosted hub cluster, or
+  - Set up proper networking (load balancer, VPN, ingress, etc.) to expose your hub API server with a publicly accessible endpoint
+
+- **Local testing (both hub and managed on the same machine)**: For testing with multiple local clusters (e.g., two kind clusters on the same machine), the localhost URL works when using the `--force-internal-endpoint-lookup` flag. See the [Register a cluster]({{< ref "/docs/getting-started/installation/register-a-cluster" >}}) documentation for details.
+
+For production deployments, it's recommended to use a hub cluster that provides a stable, network-accessible API server endpoint.
+
 ## Check out the running instances of the control plane
 
 ```shell


### PR DESCRIPTION
## Summary

This PR clarifies the network requirements and deployment scenarios in the getting started documentation to prevent confusion when setting up OCM with different cluster types.

## Changes

### start-the-control-plane.md
- Added "Important Note on Network Accessibility" section explaining that localhost hub API server URLs (e.g., from kind clusters) won't work with remote cloud-hosted managed clusters
- Provided guidance on different deployment scenarios and network requirements

### register-a-cluster.md
- Added "Understanding deployment scenarios" section with clear explanations of:
  - When to use `--force-internal-endpoint-lookup` (both clusters local)
  - Cloud provider requirements (network-accessible hub, no localhost URLs)
  - EKS special requirements (registration drivers)
- Reorganized all command example tabs for clarity:
  - `kind (local testing)` - for two kind clusters on the same machine
  - `GKE, AKS, other cloud providers` - with explicit warnings about localhost limitations
  - `EKS` - directing to dedicated EKS documentation
  - `k3s, openshift 4.X` - standard approach
- Applied consistent tab structure across all deployment modes (standard, hosted mode, singleton mode)

## Issue Reference

Fixes open-cluster-management-io/ocm#958

The issue reported that following the docs to register a GKE cluster to a kind hub failed because the managed cluster couldn't reach the localhost hub API server URL. This PR makes the network requirements explicit and provides clear guidance for different deployment scenarios.

## Test Plan

- [x] Reviewed documentation for accuracy
- [x] Ensured markdown formatting is correct
- [x] Verified all links and references work
- [x] Confirmed tab structures render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)